### PR TITLE
Fix warnings in C code

### DIFF
--- a/cbits/http.c
+++ b/cbits/http.c
@@ -753,11 +753,11 @@ static void
 _http_print_html(FILE *out, FILE *in)
 {
 	size_t len;
-  size_t sz = 1024;
+	size_t sz = 1024;
 	char *line, *p, *q;
 	int comment, tag;
 
-  line = calloc(1024, sizeof(char));
+	line = calloc(1024, sizeof(char));
 	comment = tag = 0;
 	while ((len = getline(&line, &sz, in)) > 0) {
 		while (len && isspace(line[len - 1]))

--- a/cbits/http.c
+++ b/cbits/http.c
@@ -753,11 +753,11 @@ static void
 _http_print_html(FILE *out, FILE *in)
 {
 	size_t len;
-    unsigned int sz = 1024;
+  size_t sz = 1024;
 	char *line, *p, *q;
 	int comment, tag;
 
-    line = (char *)calloc(1024, sizeof(char));
+  line = calloc(1024, sizeof(char));
 	comment = tag = 0;
 	while ((len = getline(&line, &sz, in)) > 0) {
 		while (len && isspace(line[len - 1]))


### PR DESCRIPTION
These warnings are fixed now:
```
cbits/http.c: In function ?_http_print_html?:

cbits/http.c:762:0:
     warning: passing argument 2 of ?getline? from incompatible pointer type

/usr/include/stdio.h:673:0:
     note: expected ?size_t * __restrict__? but argument is of type ?unsigned int *?
cbits/http.c: In function ?_http_print_html?:

cbits/http.c:762:0:
     warning: passing argument 2 of ?getline? from incompatible pointer type

/usr/include/stdio.h:673:0:
     note: expected ?size_t * __restrict__? but argument is of type ?unsigned int *?
```