### PR TITLE
Fixing build on apple OSes

### DIFF
--- a/cbits/ftp.c
+++ b/cbits/ftp.c
@@ -63,7 +63,9 @@
 #include <netinet/in.h>
 
 #include <ctype.h>
+#ifndef __APPLE__
 #include <libio.h>
+#endif
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -582,12 +584,16 @@ _ftp_setup(conn_t *cconn, conn_t *dconn, int mode)
 	io->dconn = dconn;
 	io->dir = mode;
 	io->eof = io->err = 0;
-    cookie_io_functions_t cookies;
-    cookies.read = (cookie_read_function_t *)_ftp_readfn;
-    cookies.write = (cookie_write_function_t *)_ftp_writefn;
-    cookies.seek = (cookie_seek_function_t *)_ftp_seekfn;
-    cookies.close = (cookie_close_function_t *)_ftp_closefn;
-    f = fopencookie(io, "rw", cookies);
+#ifndef __APPLE__
+	cookie_io_functions_t cookies;
+	cookies.read = (cookie_read_function_t *)_ftp_readfn;
+	cookies.write = (cookie_write_function_t *)_ftp_writefn;
+	cookies.seek = (cookie_seek_function_t *)_ftp_seekfn;
+	cookies.close = (cookie_close_function_t *)_ftp_closefn;
+	f = fopencookie(io, "rw", cookies);
+#else
+	f = funopen(io, _ftp_readfn, _ftp_writefn, _ftp_seekfn, _ftp_closefn);
+#endif
 	if (f == NULL)
 		free(io);
 	return (f);

--- a/cbits/http.c
+++ b/cbits/http.c
@@ -67,7 +67,9 @@
 #include <sys/socket.h>
 
 #include <ctype.h>
+#ifndef __APPLE__
 #include <libio.h>
+#endif
 #include <err.h>
 #include <errno.h>
 #include <locale.h>
@@ -321,12 +323,16 @@ _http_funopen(conn_t *conn, int chunked)
 	}
 	io->conn = conn;
 	io->chunked = chunked;
-    cookie_io_functions_t cookie;
-    cookie.read = (cookie_read_function_t *)_http_readfn;
-    cookie.write = (cookie_write_function_t *)_http_writefn;
-    cookie.seek = (cookie_seek_function_t *)NULL;
-    cookie.close = (cookie_close_function_t *)_http_closefn;
-    f = fopencookie(io, "rw", cookie);
+#ifndef __APPLE__
+	cookie_io_functions_t cookie;
+	cookie.read = (cookie_read_function_t *)_http_readfn;
+	cookie.write = (cookie_write_function_t *)_http_writefn;
+	cookie.seek = (cookie_seek_function_t *)NULL;
+	cookie.close = (cookie_close_function_t *)_http_closefn;
+	f = fopencookie(io, "rw", cookie);
+#else
+	f = funopen(io, _http_readfn, _http_writefn, NULL, _http_closefn);
+#endif
 	if (f == NULL) {
 		_download_syserr();
 		free(io);


### PR DESCRIPTION
Some quick Googling seems to suggest that The Right Way to determine we're building on Mac OS X is

`#ifdef __APPLE__ && __MACH__`

but I don't think we want this to be `__MACH__`-only, so I used just `__APPLE__`. Lemme know if it introduces other issues.

Fixes #4