### PR TITLE
Use stdio.h instead of libio.h

### DIFF
--- a/cbits/ftp.c
+++ b/cbits/ftp.c
@@ -64,7 +64,7 @@
 
 #include <ctype.h>
 #ifndef __APPLE__
-#include <libio.h>
+#include <stdio.h>
 #endif
 #include <err.h>
 #include <errno.h>

--- a/cbits/http.c
+++ b/cbits/http.c
@@ -68,7 +68,7 @@
 
 #include <ctype.h>
 #ifndef __APPLE__
-#include <libio.h>
+#include <stdio.h>
 #endif
 #include <err.h>
 #include <errno.h>


### PR DESCRIPTION
The `<libio.h>` header is supposedly provided by the Linux kernel
but has since been deprecated.
See: https://patchwork.kernel.org/patch/10158257/

Clsoes: https://github.com/psibi/download/issues/16